### PR TITLE
Access tokes can be used to access resource server if configured

### DIFF
--- a/lib/identity/access_token.rb
+++ b/lib/identity/access_token.rb
@@ -33,6 +33,7 @@ module Identity
       # Public: Creates a token from the credentials returned by OmniAuth.
       def from_omniauth_credentials(credentials)
         created_at = credentials['created_at'] || Time.now.to_i
+
         expires_at = credentials['expires_in'] ? created_at + credentials['expires_in'] : nil
 
         new(
@@ -46,6 +47,11 @@ module Identity
 
     def http_client(**kwargs)
       Identity.http_client(access_token: token, **kwargs)
+    end
+
+    # Client for a resource server if configurated
+    def http_resource_client(**kwargs)
+      Identity.http_client(access_token: token, resource: true, **kwargs)
     end
 
     # Creates a new access token using the refresh token.

--- a/lib/identity/config_validator.rb
+++ b/lib/identity/config_validator.rb
@@ -14,6 +14,7 @@ module Identity
       required(:client_secret).filled(:string)
       required(:client_uri).filled(:string)
       optional(:refresh_token_within).filled(:integer).value(gteq?: 0)
+      optional(:resource_uri).value(:string)
     end
 
     rule(:issuer) do
@@ -23,6 +24,16 @@ module Identity
       key.failure('must not have a path') unless uri.path.empty?
       key.failure('must not have a query') unless uri.query.nil?
       key.failure('must not have a fragment') unless uri.fragment.nil?
+    rescue URI::InvalidURIError
+      key.failure('must be a valid URI')
+    end
+
+    rule(:resource_uri) do
+      unless value.blank?
+        uri = URI.parse(value)
+
+        key.failure('must have a http:// or https:// scheme') if uri.scheme.nil?
+      end
     rescue URI::InvalidURIError
       key.failure('must be a valid URI')
     end


### PR DESCRIPTION
Sets up easy generation of resource server client

Goes with: 
quintel/etengine#1495
quintel/etmodel#4408
quintel/my-etm#72